### PR TITLE
Filename lint and other fun.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,20 +3,19 @@
     "formidable/configurations/es6-react",
     "plugin:flowtype/recommended"
   ],
-  "parser": "babel-eslint",
   "plugins": [
-    "babel",
-    "react",
     "flowtype"
   ],
-  "ecmaFeatures": {
-    "jsx": true,
-    "restParams": true,
-    "spread": true,
-    "experimentalObjectRestSpread": true
-  },
   "rules": {
     "quotes": ["error", "single", { "avoidEscape": true }],
-    "react/prefer-es6-class": 0
+    "react/prefer-es6-class": 0,
+
+    // Allow camelCase *only* for `export default <name>` matched filename.
+    //
+    // TODO: Review `eslint-config-formidable` discussion after decisions and
+    // potentially retrofit this repo to dash-case filenames.
+    // https://github.com/FormidableLabs/eslint-config-formidable/issues/29
+    "filenames/match-regex": ["error", "^[a-z0-9\\-\\.]+$", true],
+    "filenames/match-exported": "error"
   }
 }

--- a/lib/createResponsiveStyleSheet.js
+++ b/lib/createResponsiveStyleSheet.js
@@ -4,7 +4,7 @@ import { StyleSheet } from 'react-native';
 import type { StyleSheet as StyleSheetType } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import isResponsive from './isResponsive';
 
-export default function createResponsiveStylesheet(styles: {}): StyleSheetType<*> {
+export default function createResponsiveStyleSheet(styles: {}): StyleSheetType<*> {
   const standard = {};
   const responsive = {};
 

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "author": "Jani Eväkallio",
   "license": "MIT",
   "scripts": {
-    "lint": "eslint index.js lib/",
+    "lint": "eslint index.js lib",
     "flow": "flow check",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run lint && npm run flow"
   },
   "dependencies": {
     "react-native-orientation-listener": "0.0.4"
@@ -33,7 +33,7 @@
   "devDependencies": {
     "babel-eslint": "^6.0.2",
     "eslint": "^2.10.2",
-    "eslint-config-formidable": "^1.0.1",
+    "eslint-config-formidable": "^2.0.1",
     "eslint-plugin-babel": "^3.2.0",
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-flowtype": "^2.19.0",


### PR DESCRIPTION
- Update `eslint-config-formidable` to get proper `filenames` rules.
- Add overrides for `filenames` pending FormidableLabs/eslint-config-formidable#29
- Fix incorrect match export name.
- Implement `package.json:scripts.test`

/cc @jevakallio @Aweary 
