### PR TITLE
Add compatibility for deprecated Navigator package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import ReactNative from 'react-native';
+import Navigator from 'react-native-deprecated-custom-components';
 
 import configureLayoutAnimation from './lib/configureLayoutAnimation';
 import createResponsiveComponent from './lib/createResponsiveComponent';
@@ -25,6 +26,7 @@ module.exports = {
   ListView: wrap(ReactNative.ListView),
   MapView: wrap(ReactNative.MapView),
   Modal: wrap(ReactNative.Modal),
+  Navigator: wrap(Navigator),
   NavigatorIOS: wrap(ReactNative.NavigatorIOS),
   Picker: wrap(ReactNative.Picker),
   PickerIOS: wrap(ReactNative.PickerIOS),

--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ module.exports = {
   ListView: wrap(ReactNative.ListView),
   MapView: wrap(ReactNative.MapView),
   Modal: wrap(ReactNative.Modal),
-  Navigator: wrap(ReactNative.Navigator),
   NavigatorIOS: wrap(ReactNative.NavigatorIOS),
   Picker: wrap(ReactNative.Picker),
   PickerIOS: wrap(ReactNative.PickerIOS),

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "npm run lint && npm run flow"
   },
   "dependencies": {
+    "react-native-deprecated-custom-components": "^0.1.1",
     "react-native-orientation-listener": "0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Using React Native Version 0.46.0, this package threw the follow error because of the deprecated Navigator package: 
![image](https://user-images.githubusercontent.com/11842491/30892006-3a1c4f1a-a304-11e7-9821-e5d871514370.png)
Importing Navigator from react-native-deprecated-custom-components solved the issue. 
