### PR TITLE
PropTypes Import Change

### DIFF
--- a/lib/createResponsiveComponent.js
+++ b/lib/createResponsiveComponent.js
@@ -1,6 +1,7 @@
 // @flow
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Orientation from 'react-native-orientation-listener';
 
 import getCurrentOrientation from './getCurrentOrientation';


### PR DESCRIPTION
React.PropTypes has moved into a different package since React v15.5. That package is prop-types